### PR TITLE
ci: Add GitHub pages deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+# Useful guides:
+# https://www.sphinx-doc.org/en/master/tutorial/deploying.html
+# https://marcomadera.com/blog/github-pages
+# https://coderefinery.github.io/documentation/gh_workflow/
+
+name: Deploy docs to GH Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - name: Comment on PR
+      uses: hasura/comment-progress@v2
+      if: github.ref != 'refs/heads/main'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        number: ${{ github.event.number }}
+        id: deploy-preview
+        message: "Starting deployment of preview ⏳..."
+
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Build pages
+      run: make html
+
+    - name: Deploy if this is a push in the `main` branch
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: _build/html/
+    
+    - name: Set PR preview path and domain ENVVARS if this is a PR
+      if: github.ref != 'refs/heads/main'
+      run: |
+        echo "PR_PATH=pull/${{github.event.number}}" >> $GITHUB_ENV
+        echo "DOMAIN=${{ github.actor }}.github.io" >> $GITHUB_ENV
+
+    - name: Set base URL for preview if this is a PR
+      if: github.ref != 'refs/heads/main'
+      run: |
+        echo "BASE_URL=https://${{ env.DOMAIN }}/${{ github.event.repository.name }}/${{ env.PR_PATH}}/" >> $GITHUB_ENV
+
+    - name: Deploy to preview if this is a PR
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref != 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: _build/html/
+        destination_dir: ${{ env.PR_PATH }}
+    
+    - name: Update PR preview comment if this a PR
+      uses: hasura/comment-progress@v2
+      if: github.ref != 'refs/heads/main'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        number: ${{ github.event.number }}
+        id: deploy-preview
+        message: "A preview of ${{ github.event.after }} is uploaded and can be seen here:\n\n 🚀 ${{ env.BASE_URL }} 🚀"

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,33 @@
+name: Delete preview on PR close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete_preview:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: write
+        pull-requests: write
+    env:
+      PR_PATH: pull/${{github.event.number}}
+    steps:
+      - name: Create empty dir
+        run: mkdir _build
+
+      - name: Delete preview folder
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_build/
+          destination_dir: ${{ env.PR_PATH }}
+
+      - name: Comment on PR
+        uses: hasura/comment-progress@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          number: ${{ github.event.number }}
+          id: deploy-preview
+          message: "🪓 PR closed, deleted preview at https://github.com/${{ github.repository }}/tree/gh-pages/${{ env.PR_PATH }}/"


### PR DESCRIPTION
Includes ci tasks to deploy docs to production pages on push to main branch, 
and to deploy PR changes docs to test page for easier preview. 

Previews are cleaned once the PR is closed.